### PR TITLE
Fixed broken !logs match command

### DIFF
--- a/LogDiscordBot/classes/LogDiscordBot.py
+++ b/LogDiscordBot/classes/LogDiscordBot.py
@@ -344,7 +344,7 @@ class LogBotEssentials:
         # Get the log with the most amount and the highest time
         for i in sortedlogsbytime:
             # if log is above minplayers and not higher than 9
-            if (sortedlogidsbyamount[i] >= minplayers and sortedlogidsbyamount[i] <= format):
+            if (sortedlogidsbyamount[i] >= minplayers and sortedlogidsbyamount[i] <= int(format)):
                 matchid = i
                 logtime = LogBotEssentials().totime(checklogs[matchid])
 


### PR DESCRIPTION
format is a string not an integer, so when attempting to use format directly in a logical comparison, an exception is thrown. Converting format to an int on the fly sorts things out.